### PR TITLE
coff.h: Use extern for coff_config

### DIFF
--- a/coff.h
+++ b/coff.h
@@ -61,14 +61,14 @@ struct example {
  * - 16 = flag
  */
 
-struct {
+struct confi {
   char cwd[PATH_MAX];
   char home[PATH_MAX];
   char quest_directory[PATH_MAX];
   char test_directory[PATH_MAX];
   char null_directory[PATH_MAX];
   uint8_t opt : 5;
-}coff_config;
+}extern coff_config;
 
 /* ========================================================================= */
 /* Used by main to communicate with parse_opt.

--- a/main.c
+++ b/main.c
@@ -7,6 +7,7 @@
 /* Local Headers */
 #include "coff.h"
 
+struct confi coff_config;
 /* ------------------------------------------------------------------------- */
 /* ARGP definitions */
 


### PR DESCRIPTION
In coff.h, the coff_config was direcrtly declared and was used as a global
variable. Since extern key was missing, it was showing multiple
definitions.

Signed-off-by: Vaibhav Gupta <vaibhavgupta40@gmail.com>